### PR TITLE
Updated atom instructions to use regular autocomplete-plus

### DIFF
--- a/index.md
+++ b/index.md
@@ -27,7 +27,7 @@ Get [ASP.NET 5 for your platform](https://github.com/aspnet/home#getting-started
 
 ### [Atom](https://atom.io/)
 - Install the [Language Csharp](https://atom.io/packages/language-csharp) package.
-- Install the [Autocomplete Plus Async](https://atom.io/packages/autocomplete-plus-async) package.
+- Install the [Autocomplete Plus](https://atom.io/packages/autocomplete-plus) package.
 - Install the [Omnisharp Atom](https://atom.io/packages/omnisharp-atom) package.
 
 ### [Emacs](http://www.gnu.org/software/emacs/)


### PR DESCRIPTION
From [reading the issues](https://github.com/OmniSharp/omnisharp-atom/issues/50#issuecomment-72387618) on the omnisharp-atom repo (and from my own testing), having `autocomplete-plus-async` installed actually breaks the intellisense. Works fine just with regular `autocomplete-plus`.

