### PR TITLE
Add missing lang attribute

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     {% include head.html %}
     <body id="page-top" class="index">
     {% include nav.html %}


### PR DESCRIPTION
This is trivial PR, but adds important bit of html markup.

Having 'lang' attribute is a must according to existing
best practises. For discussion in html5bp see:
http://git.io/vJWjs

Thanks!

