### PR TITLE
Add focus state to porfolio link. Fixes #25

### DIFF
--- a/_includes/css/main.css
+++ b/_includes/css/main.css
@@ -226,6 +226,7 @@ section.success {
 .portfolio-link {
     display:block;
 }
+.portfolio-link:focus,
 .portfolio-link:hover {
     background: rgba(255,255,255,.3);
     -webkit-transition: all ease .9s;


### PR DESCRIPTION
This just add visible distinct state when interactive element has
browser focus. As there is no outline, that is required to let users
see interactive elements at all on some devices:

![navigation](https://cloud.githubusercontent.com/assets/14539/7440728/98608288-f0c5-11e4-8768-874d8fd12fe7.gif)

