### PR TITLE
Update browser page address on navigation. Fixes #24

### DIFF
--- a/js/freelancer.js
+++ b/js/freelancer.js
@@ -5,13 +5,25 @@
  */
 
 // jQuery for page scrolling feature - requires jQuery Easing plugin
+// The original function has been modified to provide support for page linking
+// In modern browsers HTML5 History.pushState is used to update location
+// in older browsers native behavior of location.hash is used and
+// no animated scroll occurs. In effect the navigation is progressively
+// enhanced with animations on supporting browsers.
 $(function() {
-    $('.page-scroll a').bind('click', function(event) {
-        var $anchor = $(this);
-        $('html, body').stop().animate({
-            scrollTop: $($anchor.attr('href')).offset().top
-        }, 1500, 'easeInOutExpo');
-        event.preventDefault();
+    $(document.body).on('click', '.page-scroll a', function(event) {
+        if(history.pushState) {
+          var $anchor = $(this),
+            hash = $anchor.attr('href');
+          event.preventDefault();
+          // avoid dups in history hash
+          if(window.location.hash !== hash) {
+            history.pushState(null, null, hash);
+          }
+          $('html, body').stop().animate({
+              scrollTop: $(hash).offset().top
+          }, 1500, 'easeInOutExpo');
+        }
     });
 });
 


### PR DESCRIPTION
If accepted this PR enables bookmarking and url sharing, so people can navigate within content of the page.

This commit modifies original function in that way that
clicking on navigation menu will in effect update browser
location allowing url sharing and bookmarking, etc.
In modern browsers HTML5 History.pushState is used together
with animation effect - while on older browser fall back is
provided by just doing nothing - which in effect will simply
update window.location.hash and scroll page in browser as per
specification.

![navigation](https://cloud.githubusercontent.com/assets/14539/7441270/494f6dba-f0e0-11e4-9632-5ac5d4dfc378.gif)

Thanks!
