### PR TITLE
Add alt attributes to images

### DIFF
--- a/_includes/about.html
+++ b/_includes/about.html
@@ -24,16 +24,16 @@ The project was initially started by <a href="https://twitter.com/jasonimison">J
             </div>
             <div class="row" >
                 <div class="col-lg-4">
-                    <img src="/images/leader-image-1.png" class="pull-right">
+                    <img src="/images/leader-image-1.png" class="pull-right" alt="">
                     <p>We unapologetically love <strong>.NET</strong>. We love its languages and all <a href="http://www.nuget.org">its libraries and frameworks</a>. We also love Sublime, Atom, Emacs, Vim and Brackets. </p>
                 </div>
                 <div class="col-lg-4">
-                    <img src="/images/leader-image-2.png" class="pull-right">
+                    <img src="/images/leader-image-2.png" class="pull-right" alt="">
                     <p>We create <a href="http://owin.org/">OWIN middleware</a> on Ubuntu and deploy to Azure. We make ASP.NET services from our Macs and deploy to Linux. </p>
 
                 </div>
                 <div class="col-lg-4">
-                    <img src="/images/leader-image-3.png" class="pull-right">
+                    <img src="/images/leader-image-3.png" class="pull-right" alt="">
                     <p>And we do all this while still using useful features like Intellisense, Add Reference, Format Document, and lots more. </p>
                 </div>
             </div>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -9,7 +9,9 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <a class="navbar-brand" href="#page-top"><img src="/images/logo-text-h.png" /></a>
+                <a class="navbar-brand" href="#page-top">
+                  <img src="/images/logo-text-h.png" alt="OmniSharp">
+                </a>
             </div>
 
             <!-- Collect the nav links, forms, and other content for toggling -->


### PR DESCRIPTION
The obvious case is OmniSharp logo - it just needs an alt as it has no
textual context at all within containing link tag.
The images in about section seem to have no actual corresponding
meaning to containing section and can be skipped from rendering by some
agents - hence change from no alt to empty alt attribute

Thanks!