### PR TITLE
Add missing or misplaced tags to improve rendering

### DIFF
--- a/_includes/about.html
+++ b/_includes/about.html
@@ -9,7 +9,7 @@
             </div>
             <div class="row">
                 <div class="col-lg-6">
-                    <p>OmniSharp is a set of tooling, editor integrations and libraries that together create an ecosystem that allows you to have a great programming experience no matter what your editor and operating system of choice may be.<p>
+                    <p>OmniSharp is a set of tooling, editor integrations and libraries that together create an ecosystem that allows you to have a great programming experience no matter what your editor and operating system of choice may be.</p>
                 </div>
                 <div class="col-lg-6">
                     <p>The OmniSharp project has been made by the community for the community, While a few of us work for Microsoft, this project is a community effort and not sponsored or endorsed by Microsoft. 

--- a/_includes/team.html
+++ b/_includes/team.html
@@ -4,8 +4,8 @@
                 <div class="col-lg-12 text-center">
                     <h2>Meet The Team</h2>
                     <hr class="star-primary">
-                    <p><strong>We are not some secret organization, you can join us too! Help is always appreciated.</p>
-<p><a class="btn btn-warning" href="https://jabbr.net/#/rooms/omnisharp">Come hang out with us on JabbR</a></strong></p>
+                    <p><strong>We are not some secret organization, you can join us too! Help is always appreciated.</strong></p>
+<p><a class="btn btn-warning" href="https://jabbr.net/#/rooms/omnisharp"><strong>Come hang out with us on JabbR</strong></a></p>
                 </div>
             </div>
             <div class="row">


### PR DESCRIPTION
This PR fixes two similar problems with markup:
- add closing paragraph tag as it could break rendering in some browsers. 
- correct strong tag placement which changes actual rendering of content

The incorrect closing `p` tag could be problem. The misplaced `strong` tags actually caused rendering problems. Below is screenshot on how Chrome (OS X) rendered the same markup before and after correction:
![20150502162119](https://cloud.githubusercontent.com/assets/14539/7441441/898712ae-f0e8-11e4-9f7d-2da6f1770219.jpg)
and actual rendering on screen:
![20150502162431](https://cloud.githubusercontent.com/assets/14539/7441445/96e60626-f0e8-11e4-97fc-94c082b593fe.jpg)

Thanks!

