### PR TITLE
Add semantic information via JSON-LD. Closes #34

### DIFF
--- a/_includes/js.html
+++ b/_includes/js.html
@@ -19,3 +19,21 @@
 
     <!-- Custom Theme JavaScript -->
     <script src="{{ "/js/freelancer.js" }}"></script>
+
+    <!-- JSON for Linked Data microdata for SEO -->
+    <script type="application/ld+json">
+    {
+      "@context": "http://schema.org/",
+      "@type": "Organization",
+      "name": "OmniSharp",
+      "description": "OmniSharp is a family of Open Source projects, each with one goal: To enable a great .NET experience in YOUR editor of choice",
+      "founder": {
+        "@type": "Person",
+        "name": "Jason Imison",
+        "url": "https://twitter.com/jasonimison"
+      },
+      "logo": "http://www.omnisharp.net/images/logo.png",
+      "url": "http://www.omnisharp.net",
+      "sameAs": "https://github.com/OmniSharp"
+    }
+    </script>


### PR DESCRIPTION
The JSON-LD format is now supported via Google, Yandex (so DuckDuckGo).
The script and markup validated with Google structured data testing machine.

Thanks!