### PR TITLE
Add Twitter summary Card meta. Closes #33

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,6 +4,12 @@
     <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
     <meta name="viewport" content="width=device-width">
     <meta name="description" content="{{ site.description }}">
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:site" content="@omnisharp" />
+    <meta name="twitter:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}" />
+    <meta name="twitter:description" content="{{ site.description }}" />
+    <meta name="twitter:image" content="{{ "/images/logo.png" | prepend: site.url }}" />
+    <meta name="twitter:url" content="{{ site.url }}" />
     <link rel="icon" type="image/png" href="favicon.png">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.url }}">
     <link rel="alternate" type="application/rss+xml" title="RSS" href="/feed.xml">


### PR DESCRIPTION
This commit adds summary type of Twitter Card for @omnisharp account.
The markup should be validated after updates is make public.

Here is generated markup with data:
```html
<meta name="twitter:card" content="summary" />
<meta name="twitter:site" content="@omnisharp" />
<meta name="twitter:title" content="OmniSharp - .NET and Intellsense on any platform with your editor of choice" />
<meta name="twitter:description" content="OmniSharp is a family of Open Source projects, each with one goal - To enable great .NET development in YOUR editor of choice." />
<meta name="twitter:image" content="http://www.omnisharp.net/images/logo.png" />
<meta name="twitter:url" content="http://www.omnisharp.net" />
```

As mentioned in commit, if this PR is merged and change is made public, the markup should be validated using Twitter validator tool:
https://cards-dev.twitter.com/validator
and person owning `@omnisharp` account should submit card via validator for approval.

There is already `robots.txt` is place, which is non-documented requirement for successful validator.

Thanks!