### PR TITLE
Fix typo and letter case in IntelliSense term

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
 ---
-title: OmniSharp - .NET and Intellsense on any platform with your editor of choice
+title: OmniSharp - .NET and IntelliSense on any platform with your editor of choice
 layout: default
 ---
 


### PR DESCRIPTION
Fix only where it make sense in the source file. The title is used on the web site head title
and meta. This commit will fix title of the website crawled by spiders.

![20150507231234](https://cloud.githubusercontent.com/assets/14539/7526064/ffd47d8c-f50e-11e4-8ab5-614dfea79df3.jpg)

The web site should be submitted to be reindexed, so the correct title is shown to users.

I assume that is so obvious to VS/.NET users that nobody noticed :)

Thanks!
