### PR TITLE
Update command line tools syntax to current .NET tools. Closes #41

### DIFF
--- a/_integrations/console.md
+++ b/_integrations/console.md
@@ -6,9 +6,9 @@ header: Command Line
 
 ### Command line only
 - Create projects using <a href="https://www.npmjs.org/package/generator-aspnet">yeoman aspnet generators</a>
-- Build projects using <code>kpm build</code>
-- Run project from the command line with <code>k web</code> or <code>k run</code>
-- Package projects for publishing with <code>kpm pack</code>
+- Build projects using <code>dnu build</code>
+- Run project from the command line with <code>dnx . web</code> or <code>dnx . run</code>
+- Package projects for publishing with <code>dnu pack</code>
 
 ### Yeoman generators
 

--- a/index.md
+++ b/index.md
@@ -57,9 +57,9 @@ And more info in the [OmniSharp Atom wiki](https://github.com/OmniSharp/omnishar
     
 ### Command line only
 - Create projects using <a href="https://www.npmjs.org/package/generator-aspnet">yeoman aspnet generators</a>
-- Build projects using <code>kpm build</code>
-- Run project from the command line with <code>k web</code> or <code>k run</code>
-- Package projects for publishing with <code>kpm pack</code>
+- Build projects using <code>dnu build</code>
+- Run project from the command line with <code>dnx . web</code> or <code>dnx . run</code>
+- Package projects for publishing with <code>dnu pack</code>
 
 ### Yeoman generators
 


### PR DESCRIPTION
Hi,

This PR updates command line tools used in pages to current .NET environment tools (transition from `k` to `dnx`).

Thanks!