### PR TITLE
Add dnu restore information with snippet

### DIFF
--- a/_integrations/console.md
+++ b/_integrations/console.md
@@ -6,6 +6,7 @@ header: Command Line
 
 ### Command line only
 - Create projects using <a href="https://www.npmjs.org/package/generator-aspnet">yeoman aspnet generators</a>
+- Download _NuGet_, _npm_ and _Bower_ resources  with `dnu restore`
 - Build projects using <code>dnu build</code>
 - Run project from the command line with <code>dnx . web</code> or <code>dnx . run</code>
 - Package projects for publishing with <code>dnu pack</code>

--- a/index.md
+++ b/index.md
@@ -57,6 +57,7 @@ And more info in the [OmniSharp Atom wiki](https://github.com/OmniSharp/omnishar
     
 ### Command line only
 - Create projects using <a href="https://www.npmjs.org/package/generator-aspnet">yeoman aspnet generators</a>
+- Download _NuGet_, _npm_ and _Bower_ resources  with `dnu restore`
 - Build projects using <code>dnu build</code>
 - Run project from the command line with <code>dnx . web</code> or <code>dnx . run</code>
 - Package projects for publishing with <code>dnu pack</code>


### PR DESCRIPTION
The command line information section has been missing short info and
sample about dependencies installation under new .NET environment.
This PR adds that information so it now shows the same bits of info that `generator-aspnet`:

![image](https://cloud.githubusercontent.com/assets/14539/7893371/78b89f62-065d-11e5-8fe0-e3be559a3dd7.png)

As this is a very simple PR it comes without starting issue first,
Thanks!