### PR TITLE
Updated command-line integration

### DIFF
--- a/_integrations/console.md
+++ b/_integrations/console.md
@@ -6,10 +6,10 @@ header: Command Line
 
 ### Command line only
 - Create projects using <a href="https://www.npmjs.org/package/generator-aspnet">yeoman aspnet generators</a>
-- Download _NuGet_, _npm_ and _Bower_ resources  with `dnu restore`
-- Build projects using <code>dnu build</code>
-- Run project from the command line with <code>dnx . web</code> or <code>dnx . run</code>
-- Package projects for publishing with <code>dnu pack</code>
+- Download _NuGet_, _npm_ and _Bower_ resources  with `dotnet restore`
+- Build projects using <code>dotnet build</code>
+- Run project from the command line with <code>dotnet run</code>
+- Package projects for publishing with <code>dotnet pack</code>
 
 ### Yeoman generators
 


### PR DESCRIPTION
Command-line integration was still referring to dnu and dnx instead of the new dotnet-cli
